### PR TITLE
Disable progress bars to avoid IO errors

### DIFF
--- a/app/services/generate_video.py
+++ b/app/services/generate_video.py
@@ -276,6 +276,7 @@ def merge_materials(
             temp_audiofile_path=output_dir,
             threads=threads,
             fps=fps,
+            logger=None,
         )
         logger.success(f"素材合并完成: {output_path}")
     except Exception as e:

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -405,7 +405,14 @@ def compress_video(input_path: str, output_path: str):
 
     try:
         clip = VideoFileClip(input_path)
-        clip.write_videofile(output_path, codec='libx264', audio_codec='aac', bitrate="500k", audio_bitrate="128k")
+        clip.write_videofile(
+            output_path,
+            codec='libx264',
+            audio_codec='aac',
+            bitrate="500k",
+            audio_bitrate="128k",
+            logger=None
+        )
     except subprocess.CalledProcessError as e:
         logger.error(f"视频压缩失败: {e}")
         raise

--- a/app/services/video.py
+++ b/app/services/video.py
@@ -351,7 +351,8 @@ def generate_video_v3(
         output_path,
         codec='libx264',
         audio_codec='aac',
-        fps=video.fps
+        fps=video.fps,
+        logger=None
     )
     logger.info(f"视频已导出到: {output_path}")  # 调试信息
 


### PR DESCRIPTION
## Summary
- disable moviepy progress bars when exporting video clips
- ensure compress_video doesn't use progress bars

## Testing
- `pytest -q` *(fails: ImportError in `test_gemini.py`)*

------
https://chatgpt.com/codex/tasks/task_e_685df6bcdca0832b942d90187be39c4c