### PR TITLE
Improve Windows/Linux hwaccel checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ _**注意⚠️：近期在 x (推特) 上发现有人冒充作者在 pump.fun �
 - 若使用 Azure TTS 服务，`requirements.txt` 已包含 `azure-cognitiveservices-speech`
 - 已安装 [FFmpeg](https://ffmpeg.org/) 并确保 `ffmpeg` 命令在系统 PATH 中。
   项目会在启动时自动检测可用的硬件加速（如 macOS VideoToolbox、
-  Windows NVENC 或 Linux VAAPI），检测结果也可通过
+  Windows NVENC 或 Linux VAAPI）。检测逻辑会额外检查可用的编码器，
+  并使用一段 64x64 黑帧验证实际编码能力。检测结果也可通过
   `python app/utils/ffmpeg_utils.py` 查看。
 
 ## 反馈建议 📢


### PR DESCRIPTION
## Summary
- refine Windows AMD/NVENC/QSV tests and log return codes
- refine Linux NVENC/VAAPI/QSV tests and log return codes
- validate hwaccel with 64x64 clips on all platforms

## Testing
- `python -m py_compile app/utils/ffmpeg_utils.py`
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_685e0c72138c832bb53dae000097da2f