### PR TITLE
Add Azure TTS config example

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -87,3 +87,9 @@
     frame_interval_input = 3
     # 大模型单次处理的关键帧数量
     vision_batch_size = 10
+
+[azure]
+    # Azure TTS 服务区域，如 eastus 或 westeurope
+    speech_region = ""
+    # Azure TTS API Key
+    speech_key = ""


### PR DESCRIPTION
## Summary
- add Azure TTS section to `config.example.toml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e1eaad034832ba6e448e0afab103f