### PR TITLE
Fix otf font selection

### DIFF
--- a/webui/utils/cache.py
+++ b/webui/utils/cache.py
@@ -8,7 +8,8 @@ def get_fonts_cache(font_dir):
         fonts = []
         for root, dirs, files in os.walk(font_dir):
             for file in files:
-                if file.endswith(".ttf") or file.endswith(".ttc"):
+                lower = file.lower()
+                if lower.endswith(".ttf") or lower.endswith(".ttc") or lower.endswith(".otf"):
                     fonts.append(file)
         fonts.sort()
         st.session_state['fonts_cache'] = fonts


### PR DESCRIPTION
## Summary
- include `.otf` files when caching available fonts

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'moviepy.editor')*

------
https://chatgpt.com/codex/tasks/task_e_685e2671bb5c832b8e8d7f80c0fa6d50