### PR TITLE
Fix subtitle creation failure handling

### DIFF
--- a/app/services/voice.py
+++ b/app/services/voice.py
@@ -1454,7 +1454,18 @@ def tts_multiple(task_id: str, list_script: list, voice_name: str, voice_rate: f
                 continue
             else:
                 # 为当前片段生成字幕文件
-                _, duration = create_subtitle(sub_maker=sub_maker, text=text, subtitle_file=subtitle_file)
+                subtitle_result = create_subtitle(
+                    sub_maker=sub_maker,
+                    text=text,
+                    subtitle_file=subtitle_file,
+                )
+                if subtitle_result:
+                    _, duration = subtitle_result
+                else:
+                    logger.error(
+                        f"无法为时间戳 {timestamp} 创建字幕文件: {subtitle_file}"
+                    )
+                    duration = get_audio_duration(sub_maker)
 
             tts_results.append({
                 "_id": item['_id'],


### PR DESCRIPTION
## Summary
- handle failure in create_subtitle when generating subclips

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685e296e5be4832bba7fa36e89b88f44